### PR TITLE
Db schemas

### DIFF
--- a/controllers/athletesController.js
+++ b/controllers/athletesController.js
@@ -1,0 +1,37 @@
+const db = require("../models");
+
+// Defining methods for the athletesController
+module.exports = {
+  findAll: (req, res) => {
+    db.Athletes
+      .find(req.query)
+      .sort({ date: -1 })
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  },
+  findById: (req, res) => {
+    db.Athletes
+      .findById(req.params.id)
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  },
+  create: (req, res) => {
+    db.Athletes
+      .create(req.body)
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  },
+  update: (req, res) => {
+    db.Athletes
+      .findOneAndUpdate({ _id: req.params.id }, req.body,
+                        { new: true, runValidators: true })
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  },
+  remove: (req, res) => {
+    db.Athletes
+      .findByIdAndRemove({ _id: req.params.id })
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  }
+};

--- a/controllers/coachesController.js
+++ b/controllers/coachesController.js
@@ -1,0 +1,37 @@
+const db = require("../models");
+
+// Defining methods for the coachesController
+module.exports = {
+  findAll: (req, res) => {
+    db.Coaches
+      .find(req.query)
+      .sort({ date: -1 })
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  },
+  findById: (req, res) => {
+    db.Coaches
+      .findById(req.params.id)
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  },
+  create: (req, res) => {
+    db.Coaches
+      .create(req.body)
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  },
+  update: (req, res) => {
+    db.Coaches
+      .findOneAndUpdate({ _id: req.params.id }, req.body,
+                        { new: true, runValidators: true })
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  },
+  remove: (req, res) => {
+    db.Coaches
+      .findByIdAndRemove({ _id: req.params.id })
+      .then(dbModel => res.json(dbModel))
+      .catch(err => res.status(422).json(err));
+  }
+};

--- a/models/address.js
+++ b/models/address.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+const Schema   = mongoose.Schema;
+
+const validator = require("validator");
+
+const addressSchema = new Schema({
+  street1: { type: String, trim: true },
+  street2: { type: String, trim: true },
+  city   : { type: String, trim: true },
+  state  : { type: String, trim: true, uppercase: true,
+             enum: ["AL","AK","AS","AZ","AR","CA","CO","CT","DE","DC",
+                    "FM","FL","GA","GU","HI","ID","IL","IN","IA","KS",
+                    "KY","LA","ME","MH","MD","MA","MI","MN","MS","MO",
+                    "MT","NE","NV","NH","NJ","NM","NY","NC","ND","MP",
+                    "OH","OK","OR","PW","PA","PR","RI","SC","SD","TN",
+                    "TX","UT","VT","VI","VA","WA","WV","WI","WY" ]},
+  zip    : { type: String, trim: true,
+             validate: {
+               validator: v => validator.isNumeric(v) &&
+                               validator.isLength(v, { min: 5, max: 5 }),
+               message  : "{VALUE} is not a valid zip code",
+               isAsync   : false
+             } 
+           }, 
+  zip4   : { type: String, trim: true,
+             validate: {
+               validator: v => validator.isNumeric(v) &&
+                               validator.isLength(v, { min: 4, max: 4 }),
+               message  : "{VALUE} is not a valid + 4 zip code",
+               isAsync   : false
+             } 
+           }
+}, { _id: false });
+
+const Address = mongoose.model("Address", addressSchema);
+
+module.exports = Address;

--- a/models/athletes.js
+++ b/models/athletes.js
@@ -1,0 +1,75 @@
+const mongoose = require("mongoose");
+const Schema   = mongoose.Schema;
+
+const Contact = require("./contact");
+const Name    = require("./name");
+const Address = require("./address");
+
+const athletesSchema = new Schema({
+  userName        : { type: String, required: true, unique: true, 
+                      trim: true, uppercase: true, minlength: 8 },  
+  // Password criteria :
+  // ^	          The password string will start this way
+  // (?=.*[a-z])	The string must contain at least 1 lowercase alphabetical character
+  // (?=.*[A-Z])	The string must contain at least 1 uppercase alphabetical character
+  // (?=.*[0-9])	The string must contain at least 1 numeric character
+  // (?=.[!@#\$%\^&])	The string must contain at least one special character, but we are escaping reserved RegEx characters to avoid conflict
+  // (?=.{8,})	The string must be eight characters or longer
+  //  ^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})
+  password        : { type: String, required: true, trim: true,
+                      validate: {
+                        validator: /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})/,
+                        message: "{VALUE} is not a valid password"
+                      }
+                    },  
+  contact         : Contact.schema,
+  name            : Name.schema,
+  address         : Address.schema,
+  parentNames     : { type: String, trim: true },
+  jerseyNum       : { type: Number },
+  gradYear        : { type: Number },
+  positions       : [{ type: String, trim: true }],
+  ncaaId          : { type: String, trim: true },  
+	birthDate       : Date, 
+  scholastic      : {
+    weightGPA     : { type: Number },
+    unweightGPA   : { type: Number },
+    classRank     : { type: Number },
+    classSize     : { type: Number },
+    scoreSAT      : { type: Number },
+    scoreACT      : { type: Number },
+    major         : { type: String, trim: true }
+  },
+  club            : {
+    name          : { type: String, trim: true },
+    team          : { type: String, trim: true },
+    director      : Name.schema,
+    coach         : Name.schema,
+    address       : Address.schema,
+    contact       : Contact.schema
+  },
+  highSchool      : {
+    name          : { type: String, trim: true },
+    coach         : Name.schema,
+    address       : Address.schema,
+    contact       : Contact.schema
+  },
+  statistics      : {
+    height        : { type: String, trim: true },
+    weight        : { type: Number },
+    handed        : { type: String, enum: ["right", "left"] }, // or R, L?
+    standReach    : { type: String, trim: true }, 
+    approachTouch : { type: String, trim: true }, 
+    blockJump     : { type: String, trim: true }, 
+  },
+  athleteAccomps  : [{ type: String, trim: true }], 
+  schoolAccomps   : [{ type: String, trim: true }],
+  videoLinks      : [{ type: String, trim: true }],
+  profileImg      : { data: Buffer, contentType: String },
+  createDate      : { type: Date, default: Date.now },
+  modifyDate      : { type: Date, default: Date.now }
+});
+
+const Athletes = mongoose.model("Athletes", athletesSchema);
+
+module.exports = Athletes;

--- a/models/athletes.js
+++ b/models/athletes.js
@@ -57,7 +57,7 @@ const athletesSchema = new Schema({
   statistics      : {
     height        : { type: String, trim: true },
     weight        : { type: Number },
-    handed        : { type: String, enum: ["right", "left"] }, // or R, L?
+    handed        : { type: String, lowercase: true, enum: ["right", "left"] },
     standReach    : { type: String, trim: true }, 
     approachTouch : { type: String, trim: true }, 
     blockJump     : { type: String, trim: true }, 

--- a/models/coaches.js
+++ b/models/coaches.js
@@ -1,0 +1,36 @@
+const mongoose = require("mongoose");
+const Schema   = mongoose.Schema;
+
+const Contact = require("./contact");
+const Name    = require("./name");
+const Address = require("./address");
+
+const coachesSchema = new Schema({
+  userName        : { type: String, required: true, unique: true, 
+                      trim: true, uppercase: true, minlength: 8 },  
+  // Password criteria :
+  // ^	          The password string will start this way
+  // (?=.*[a-z])	The string must contain at least 1 lowercase alphabetical character
+  // (?=.*[A-Z])	The string must contain at least 1 uppercase alphabetical character
+  // (?=.*[0-9])	The string must contain at least 1 numeric character
+  // (?=.[!@#\$%\^&])	The string must contain at least one special character, but we are escaping reserved RegEx characters to avoid conflict
+  // (?=.{8,})	The string must be eight characters or longer
+  //  ^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})
+  password        : { type: String, required: true, trim: true,
+                      validate: {
+                        validator: /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})/,
+                        message: "{VALUE} is not a valid password"
+                      }
+                    },             
+  contact         : Contact.schema,
+  name            : Name.schema,
+  address         : Address.schema,
+  position        : { type: String, trim: true },
+  accomplishments : [{type: String, trim: true }],
+  createDate      : { type: Date, default: Date.now },
+  modifyDate      : { type: Date, default: Date.now }
+});
+
+const Coaches = mongoose.model("Coaches", coachesSchema);
+
+module.exports = Coaches;

--- a/models/coaches.js
+++ b/models/coaches.js
@@ -26,7 +26,7 @@ const coachesSchema = new Schema({
   name            : Name.schema,
   address         : Address.schema,
   position        : { type: String, trim: true },
-  accomplishments : [{type: String, trim: true }],
+  accomplishments : [{ type: String, trim: true }],
   createDate      : { type: Date, default: Date.now },
   modifyDate      : { type: Date, default: Date.now }
 });

--- a/models/contact.js
+++ b/models/contact.js
@@ -1,0 +1,33 @@
+const mongoose = require("mongoose");
+const Schema   = mongoose.Schema;
+
+const validator = require("validator");
+
+const contactSchema = new Schema({
+  email  : { type: String, trim: true,
+             validate: {
+               validator: validator.isEmail,
+               message  : "{VALUE} is not a valid email",
+               isAsync  : false
+             }
+           },
+  phone  : { type: String, trim: true,
+             validate: {
+               validator: v => validator.isNumeric(v) &&
+                               validator.isLength(v, { min: 10, max: 10 }),
+               message  : "{VALUE} is not a valid phone number",
+               isAsync   : false
+             } 
+           },
+  url    : { type: String, trim: true,
+             validate: {
+               validator: validator.isURL,
+               message  : "{VALUE} is not a valid website",
+               isAsync  : false
+             }
+           }
+}, { _id: false });
+
+const Contact = mongoose.model("Contact", contactSchema);
+
+module.exports = Contact;

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  Athletes: require("./athletes"),
+  Coaches : require("./coaches")
+};

--- a/models/name.js
+++ b/models/name.js
@@ -1,0 +1,12 @@
+const mongoose = require("mongoose");
+const Schema   = mongoose.Schema;
+
+const nameSchema = new Schema({
+  first : { type: String, trim: true },
+  middle: { type: String, trim: true },
+  last  : { type: String, trim: true }
+}, { _id: false });
+
+const Name = mongoose.model("Name", nameSchema);
+
+module.exports = Name;

--- a/models/test/createAthlete.md
+++ b/models/test/createAthlete.md
@@ -1,0 +1,96 @@
+{
+  "userName"      : "myathleteuser",
+  "password"      : "Password123$",    
+  "contact"       : {
+                      "email": "myaccount@hotmail.com",
+                      "phone": "1234567890",
+                      "url"  : "www.youtube.com"
+                    },
+  "name"          : {
+  	                  "first" : "My   ",
+  	                  "middle": "   Test",
+  	                  "last"  : "User"
+                    },
+  "address"       : {
+                      "street1": "Street 1",
+                      "street2": "Street 2",
+                      "city"   : "My City",
+                      "state"  : "Ga",
+                      "zip"    : "12345",
+                      "zip4"   : "6789"  	
+                    },
+  "parentNames"   : "Madge and Homer",
+  "jerseyNum"     : 11,
+  "gradYear"      : 2018,
+  "positions"     : ["OH", "RS"],
+  "ncaaId"        : "12345ZZZZ",  
+	"birthDate"     : "06/19/1997", 
+  "scholastic"    : {
+                      "weightGPA"     : 3.75,
+                      "unweightGPA"   : 3.2,
+                      "classRank"     : 5,
+                      "classSize"     : 200,
+                      "scoreSAT"      : 1400,
+                      "scoreACT"      : 26,
+                      "major"         : "undecided"
+                    },
+  "club"          : {
+                      "name"          : "Synergy",
+                      "team"          : "17 Elite",
+                      "director"      : {
+  	                                      "first" : "director",
+  	                                      "middle": "m",
+  	                                      "last"  : "chief"
+                                        },
+                      "coach"         : {
+  	                                      "first" : "coach",
+  	                                      "middle": "z",
+  	                                      "last"  : "mentor"
+                                        },
+                      "address"       : {
+                                          "street1": "Street 1",
+                                          "street2": "Street 2",
+                                          "city"   : "My City",
+                                          "state"  : "Ga",
+                                          "zip"    : "12345",
+                                          "zip4"   : "6789"
+                                        },
+                      "contact"       : {
+                                          "email": "myaccount@hotmail.com",
+                                          "phone": "1234567890",
+                                          "url"  : "www.youtube.com"
+                                        }
+                    },
+  "highSchool"    : {
+                      "name"          : "County High School",
+                      "coach"         : {
+  	                                      "first" : "coach",
+  	                                      "middle": "z",
+  	                                      "last"  : "mentor"
+                                        },
+                      "address"       : {
+                                          "street1": "Street 1",
+                                          "street2": "Street 2",
+                                          "city"   : "My City",
+                                          "state"  : "Ga",
+                                          "zip"    : "12345",
+                                          "zip4"   : "6789"
+                                        },
+                      "contact"       : {
+                                          "email": "myaccount@hotmail.com",
+                                          "phone": "1234567890",
+                                          "url"  : "www.youtube.com"
+                                        }
+                    },
+  "statistics"    : {
+                      "height"        : "6'1\"",
+                      "weight"        : 155,
+                      "handed"        : "RiGht",
+                      "standReach"    : "9'8\"", 
+                      "approachTouch" : "10'2\"", 
+                      "blockJump"     : "10'0\"" 
+                    },
+  "athleteAccomps" : ["All Everything", "Great Athlete Award"], 
+  "schoolAccomps"  : ["National Honor Society", "FBLA"],
+  "videoLinks"     : ["www.youtube1.com", "www.youtube2.com"]
+}

--- a/models/test/createAthleteError.md
+++ b/models/test/createAthleteError.md
@@ -1,0 +1,96 @@
+{
+  "userName"        : "myath",
+  "password"        : "password123",    
+  "contact"       : {
+                      "email": "myaccount@hotmail.com",
+                      "phone": "1234567890",
+                      "url"  : "www.youtube.com"
+                    },
+  "name"          : {
+  	                  "first" : "My   ",
+  	                  "middle": "   Test",
+  	                  "last"  : "User"
+                    },
+  "address"       : {
+                      "street1": "Street 1",
+                      "street2": "Street 2",
+                      "city"   : "My City",
+                      "state"  : "Ga",
+                      "zip"    : "12345",
+                      "zip4"   : "6789"  	
+                    },
+  "parentNames"   : "Madge and Homer",
+  "jerseyNum"     : 11,
+  "gradYear"      : 2018,
+  "positions"     : ["OH", "RS"],
+  "ncaaId"        : "12345ZZZZ",  
+	"birthDate"     : "99/19/1997", 
+  "scholastic"    : {
+                      "weightGPA"     : 3.75,
+                      "unweightGPA"   : 3.2,
+                      "classRank"     : 5,
+                      "classSize"     : 200,
+                      "scoreSAT"      : 1400,
+                      "scoreACT"      : 26,
+                      "major"         : "undecided"
+                    },
+  "club"          : {
+                      "name"          : "Synergy",
+                      "team"          : "17 Elite",
+                      "director"      : {
+  	                                      "first" : "director",
+  	                                      "middle": "m",
+  	                                      "last"  : "chief"
+                                        },
+                      "coach"         : {
+  	                                      "first" : "coach",
+  	                                      "middle": "z",
+  	                                      "last"  : "mentor"
+                                        },
+                      "address"       : {
+                                          "street1": "Street 1",
+                                          "street2": "Street 2",
+                                          "city"   : "My City",
+                                          "state"  : "Ga",
+                                          "zip"    : "12345",
+                                          "zip4"   : "6789"
+                                        },
+                      "contact"       : {
+                                          "email": "myaccount@hotmail.com",
+                                          "phone": "1234567890",
+                                          "url"  : "www.youtube.com"
+                                        }
+                    },
+  "highSchool"    : {
+                      "name"          : "County High School",
+                      "coach"         : {
+  	                                      "first" : "coach",
+  	                                      "middle": "z",
+  	                                      "last"  : "mentor"
+                                        },
+                      "address"       : {
+                                          "street1": "Street 1",
+                                          "street2": "Street 2",
+                                          "city"   : "My City",
+                                          "state"  : "Ga",
+                                          "zip"    : "12345",
+                                          "zip4"   : "6789"
+                                        },
+                      "contact"       : {
+                                          "email": "myaccount@hotmail.com",
+                                          "phone": "1234567890",
+                                          "url"  : "www.youtube.com"
+                                        }
+                    },
+  "statistics"    : {
+                      "height"        : "6'1\"",
+                      "weight"        : 155,
+                      "handed"        : "middle",
+                      "standReach"    : "9'8\"", 
+                      "approachTouch" : "10'2\"", 
+                      "blockJump"     : "10'0\"" 
+                    },
+  "athleteAccomps" : ["All Everything", "Great Athlete Award"], 
+  "schoolAccomps"  : ["National Honor Society", "FBLA"],
+  "videoLinks"     : ["www.youtube1.com", "www.youtube2.com"]
+}

--- a/models/test/createCoach.md
+++ b/models/test/createCoach.md
@@ -1,5 +1,5 @@
 {
-  "userName"        : "mytestuser",
+  "userName"        : "mycoachuser",
   "password"        : "Password123$",    
   "contact"         : {
                         "email": "myaccount@hotmail.com",
@@ -7,8 +7,8 @@
                         "url"  : "www.youtube.com"
                       },
   "name"            : {
-  	                    "first" : "My",
-  	                    "middle": "Test",
+  	                    "first" : "My   ",
+  	                    "middle": "   Test",
   	                    "last"  : "User"
                       },
   "address"         : {

--- a/models/test/createCoach.md
+++ b/models/test/createCoach.md
@@ -1,0 +1,25 @@
+{
+  "userName"        : "mytestuser",
+  "password"        : "Password123$",    
+  "contact"         : {
+                        "email": "myaccount@hotmail.com",
+                        "phone": "1234567890",
+                        "url"  : "www.youtube.com"
+                      },
+  "name"            : {
+  	                    "first" : "My",
+  	                    "middle": "Test",
+  	                    "last"  : "User"
+                      },
+  "address"         : {
+                        "street1": "Street 1",
+                        "street2": "Street 2",
+                        "city"   : "My City",
+                        "state"  : "Ga",
+                        "zip"    : "12345",
+                        "zip4"   : "6789"
+  	
+                      },
+  "position"        : "head coach",
+  "accomplishments" : ["USAV 17s Open Champions", "USAV 16s Open Runner-Up"]
+  }

--- a/models/test/createCoachError.md
+++ b/models/test/createCoachError.md
@@ -1,5 +1,5 @@
 {
-  "userName"        : "mytestuser2",
+  "userName"        : "mycoach",
   "password"        : "password123",    
   "contact"         : {
                         "email": "myaccount#hotmail.com",
@@ -7,15 +7,15 @@
                         "url"  : "$"
                       },
   "name"            : {
-  	                    "first" : "My",
-  	                    "middle": "Test",
+  	                    "first" : "My   ",
+  	                    "middle": "   Test",
   	                    "last"  : "User"
                       },
   "address"         : {
                         "street1": "Street 1",
                         "street2": "Street 2",
                         "city"   : "My City",
-                        "state"  : "Ga",
+                        "state"  : "Zz",
                         "zip"    : "123456",
                         "zip4"   : "6789A" 	
                       },

--- a/models/test/createCoachError.md
+++ b/models/test/createCoachError.md
@@ -1,0 +1,24 @@
+{
+  "userName"        : "mytestuser2",
+  "password"        : "password123",    
+  "contact"         : {
+                        "email": "myaccount#hotmail.com",
+                        "phone": "1A34567890123",
+                        "url"  : "$"
+                      },
+  "name"            : {
+  	                    "first" : "My",
+  	                    "middle": "Test",
+  	                    "last"  : "User"
+                      },
+  "address"         : {
+                        "street1": "Street 1",
+                        "street2": "Street 2",
+                        "city"   : "My City",
+                        "state"  : "Ga",
+                        "zip"    : "123456",
+                        "zip4"   : "6789A" 	
+                      },
+  "position"        : "head coach",
+  "accomplishment"  : ["USAV 17s Open Champions", "USAV 16s Open Runner-Up"]
+  }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "axios": "^0.16.2",
     "body-parser": "^1.17.2",
     "express": "^4.15.4",
-    "mongoose": "^5.0.11"
+    "mongoose": "^5.0.11",
+    "validator": "^9.4.1"
   }
 }

--- a/routes/api/athletes.js
+++ b/routes/api/athletes.js
@@ -1,0 +1,17 @@
+const router = require("express").Router();
+const athletesController = require("../../controllers/athletesController");
+
+// Matches with "/api/athletes"
+router
+  .route("/")
+  .get(athletesController.findAll)
+  .post(athletesController.create);
+
+// Matches with "/api/athletes/:id"
+router
+  .route("/:id")
+  .get(athletesController.findById)
+  .put(athletesController.update)
+  .delete(athletesController.remove);
+
+module.exports = router;

--- a/routes/api/coaches.js
+++ b/routes/api/coaches.js
@@ -1,0 +1,17 @@
+const router = require("express").Router();
+const coachesController = require("../../controllers/coachesController");
+
+// Matches with "/api/coaches"
+router
+  .route("/")
+  .get(coachesController.findAll)
+  .post(coachesController.create);
+
+// Matches with "/api/coaches/:id"
+router
+  .route("/:id")
+  .get(coachesController.findById)
+  .put(coachesController.update)
+  .delete(coachesController.remove);
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -1,0 +1,9 @@
+const router = require("express").Router();
+const coachesRoutes = require("./coaches");
+const athletesRoutes = require("./athletes");
+
+// Articles routes
+router.use("/coaches", coachesRoutes);
+router.use("/athletes", athletesRoutes);
+
+module.exports = router;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,6 +1939,10 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
+validator@^9.4.1:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-9.4.1.tgz#abf466d398b561cd243050112c6ff1de6cc12663"
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
This change adds the user authentication, coach profile and athlete profile schemas. It also adds the basic routing for CRUD operations on coach/athlete data through /coaches, /athletes, /coaches/:id, /athletes/:id routes. I created a test directory which holds json objects for creating coach and athlete documents. The test directory gives us a template for inserting all values EXCEPT for the athlete profile document. This is NOT included in the test cases and will need to be handled when the upload code is written. The error json objects test schema validation including enum and date values. I did not repeat error tests for the subdocuments (e.g. address) in the athlete error json object. This is tested once in the coach error json object since it is reusable code.

Finally, the basic routing and other database actions (RUD - either by id or top-level) were also tested.

There is a new package which was added call validator. You will need to yarn add the package before running the node server.

NOTE: When testing the update for subdocuments, I found you need to update the entire subdocument. For example, if you want to update the first name you will need to supply an object which contains all the previous fields in the name - first, last, middle. The new object replaces the previous object.