### PR TITLE
Fix null render

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { BrowserRouter as Router, Route, Link } from "react-router-dom";
+import { BrowserRouter as Router, Route } from "react-router-dom";
 
 import PrivateRoute from "./components/PrivateRoute";
 import PropsRoute from "./components/PropsRoute";
@@ -33,21 +33,6 @@ class App extends Component {
     return (
       <Router className="container">
         <div>
-          {/* <div className="top-bar">
-            <div className="top-bar-left">
-              <Link to="/">React App</Link>
-            </div>
-            {this.state.authenticated ? (
-              <div className="top-bar-right">
-                <Link to="/logout">Log out</Link>
-              </div>
-            ) : (
-              <div className="top-bar-right">
-                <Link to="/login">Log in</Link>
-              </div>
-            )}
-          </div> */}
-
           <Nav toggleAuthenticateStatus={this.toggleAuthenticateStatus}/>
 
           <PropsRoute exact path="/" component={Home} toggleAuthenticateStatus={this.toggleAuthenticateStatus} />

--- a/client/src/components/Nav/Nav.js
+++ b/client/src/components/Nav/Nav.js
@@ -20,7 +20,6 @@ import {
   faSave,
   faLock
 } from "@fortawesome/fontawesome-free-solid";
-import { BrowserRouter as Link } from "react-router-dom";
 import Auth from "../../utils/Auth";
 
 class Nav extends React.Component {

--- a/client/src/components/NewsFeed/Newsfeed.js
+++ b/client/src/components/NewsFeed/Newsfeed.js
@@ -24,11 +24,11 @@ class Newsfeed extends Component {
         {this.state.articles.length ? (
             <div style={{ overflow: "scroll", height: 400 }}>
               {this.state.articles.map((article, index) => (
-                <ListGroup>
+                <ListGroup key={index}>
                   <ListGroupItem href={article.link} target="_blank">
-                    <div classname="row">
+                    <div className="row">
                       <div className="col-md-3" style={{ float: "left" }}>
-                        <img src={article.img} style={{ width: 220 }} />
+                        <img src={article.img} alt={`Article ${index}`} style={{ width: 220 }} />
                       </div>
                       <div className="col-md-9" style={{ float: "left" }}>
                         <h5 className="mb1">{article.title}</h5>

--- a/client/src/components/NewsFeed/Newsfeed.js
+++ b/client/src/components/NewsFeed/Newsfeed.js
@@ -5,6 +5,7 @@ import { ListGroup, ListGroupItem } from "mdbreact";
 
 class Newsfeed extends Component {
   state = {
+    ready: false,
     articles: []
   };
 
@@ -14,7 +15,7 @@ class Newsfeed extends Component {
 
   loadArticles = () => {
     API.getArticles()
-      .then(res => this.setState({ articles: res.data }))
+      .then(res => this.setState({ ready: true, articles: res.data }))
       .catch(err => console.log(err));
   };
 
@@ -22,25 +23,27 @@ class Newsfeed extends Component {
     return (
       <div>
         {this.state.articles.length ? (
-            <div style={{ overflow: "scroll", height: 400 }}>
-              {this.state.articles.map((article, index) => (
-                <ListGroup key={index}>
-                  <ListGroupItem href={article.link} target="_blank">
-                    <div className="row">
-                      <div className="col-md-3" style={{ float: "left" }}>
-                        <img src={article.img} alt={`Article ${index}`} style={{ width: 220 }} />
-                      </div>
-                      <div className="col-md-9" style={{ float: "left" }}>
-                        <h5 className="mb1">{article.title}</h5>
-                        <p className="mb1">{article.summary}</p>
-                      </div>
+          <div style={{ overflow: "scroll", height: 400 }}>
+            {this.state.articles.map((article, index) => (
+              <ListGroup key={index}>
+                <ListGroupItem href={article.link} target="_blank">
+                  <div className="row">
+                    <div className="col-md-3" style={{ float: "left" }}>
+                      <img src={article.img} alt={`Article ${index}`} style={{ width: 220 }} />
                     </div>
-                  </ListGroupItem>
-                </ListGroup>
-              ))}
-            </div>
+                    <div className="col-md-9" style={{ float: "left" }}>
+                      <h5 className="mb1">{article.title}</h5>
+                      <p className="mb1">{article.summary}</p>
+                    </div>
+                  </div>
+                </ListGroupItem>
+              </ListGroup>
+            ))}
+          </div>
         ) : (
-          <h3>No Results to Display</h3>
+          <div>
+            { this.state.ready && <h3>No Results to Display</h3> }
+          </div>
         )}
       </div>
     );

--- a/client/src/components/Search/Search.js
+++ b/client/src/components/Search/Search.js
@@ -6,6 +6,7 @@ class Search extends Component {
   state = {
     secretData: "",
     user: {},
+    ready: false,
     schools: []
   };
 
@@ -19,6 +20,7 @@ class Search extends Component {
       this.setState({
           secretData: res.data.message,
           user: res.data.user,
+          ready: true,
           schools: res.data
         }))
     .catch(err => console.log(err));
@@ -38,7 +40,9 @@ class Search extends Component {
             </div>
           </div>
         ) : (
-          <h3>No Results to Display</h3>
+          <div>
+            { this.state.ready && <h3>No Results to Display</h3> }
+          </div>
         )}
       </div>
     );

--- a/client/src/pages/Home/Home.js
+++ b/client/src/pages/Home/Home.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import Slideshow from "../../components/Slideshow";
-import SimpleCard from "../../components/SimpleCard";
 import Newsfeed from "../../components/NewsFeed";
 
 class Home extends Component {
@@ -17,7 +16,7 @@ class Home extends Component {
           <div className="col">
             <Slideshow />
             <Newsfeed />
-            </div>
+          </div>
         </div>
       </div>
     )

--- a/middleware/auth-check.js
+++ b/middleware/auth-check.js
@@ -1,6 +1,6 @@
 const jwt    = require("jsonwebtoken");
 const db     = require("../models");
-const config = ("../config");
+const config = require('../config');
 
 module.exports = (req, res, next) => {
   if (!req.headers.authorization) {
@@ -13,7 +13,9 @@ module.exports = (req, res, next) => {
   // decode the token using a secret key-phrase
   return jwt.verify(token, config.jwtSecret, (err, decoded) => {
     // the 401 code is for unauthorized status
-    if (err) { return res.status(401).end(); }
+    if (err) { 
+      console.log(err);
+      return res.status(401).end(); }
 
     const userId = decoded.sub;
 

--- a/server.js
+++ b/server.js
@@ -20,13 +20,9 @@ const localLoginStrategy = require("./passport/local-login");
 passport.use("local-signup", localSignupStrategy);
 passport.use("local-login", localLoginStrategy);
 
-// // pass the authentication checker middleware
-// const authCheckMiddleware = require("./middleware/auth-check");
-// app.use("/api", (req, res, next) => 
-//   (req.originalUrl === '/api/articles') 
-//     ? next() 
-//     : authCheckMiddleware(req, res, next)
-// );
+// pass the authentication checker middleware
+const authCheckMiddleware = require('./middleware/auth-check');
+app.use(/^\/api\/((?!(articles)).)*$/, authCheckMiddleware);
 
 // Serve up static assets
 app.use(express.static("client/build"));

--- a/server.js
+++ b/server.js
@@ -21,13 +21,12 @@ passport.use("local-signup", localSignupStrategy);
 passport.use("local-login", localLoginStrategy);
 
 // pass the authenticaion checker middleware
-
-// const authCheckMiddleware = require("./middleware/auth-check");
-// app.use((req, res, next) => 
-//   (req.originalUrl === '/api/articles') 
-//     ? next() 
-//     : authCheckMiddleware(req, res, next)
-// );
+const authCheckMiddleware = require("./middleware/auth-check");
+app.use("/api", (req, res, next) => 
+  (req.originalUrl === '/api/articles') 
+    ? next() 
+    : authCheckMiddleware(req, res, next)
+);
 
 // Serve up static assets
 app.use(express.static("client/build"));

--- a/server.js
+++ b/server.js
@@ -20,13 +20,13 @@ const localLoginStrategy = require("./passport/local-login");
 passport.use("local-signup", localSignupStrategy);
 passport.use("local-login", localLoginStrategy);
 
-// pass the authenticaion checker middleware
-const authCheckMiddleware = require("./middleware/auth-check");
-app.use("/api", (req, res, next) => 
-  (req.originalUrl === '/api/articles') 
-    ? next() 
-    : authCheckMiddleware(req, res, next)
-);
+// // pass the authentication checker middleware
+// const authCheckMiddleware = require("./middleware/auth-check");
+// app.use("/api", (req, res, next) => 
+//   (req.originalUrl === '/api/articles') 
+//     ? next() 
+//     : authCheckMiddleware(req, res, next)
+// );
 
 // Serve up static assets
 app.use(express.static("client/build"));


### PR DESCRIPTION
I added a state property which is set to false until the results are returned from the API request. This prevents the "No Results" from being rendered unless it is really true.

{ this.state.ready && <h3>No Results to Display</h3> }

Long term might be nice to have an hour glass or whatever so the user does not see empty stuff before rendering the results, but this works for now.

Merge pull requests in the order they appear on zenhub board. This pull request is already merged with the previous ones.