### PR TITLE
Fix newreg auth

### DIFF
--- a/client/src/components/NewsFeed/Newsfeed.js
+++ b/client/src/components/NewsFeed/Newsfeed.js
@@ -15,13 +15,14 @@ class Newsfeed extends Component {
 
   loadArticles = () => {
     API.getArticles()
-      .then(res => this.setState({ ready: true, articles: res.data }))
+      .then(res => this.refs.NewsfeedRef 
+                   && this.setState({ ready: true, articles: res.data }))
       .catch(err => console.log(err));
   };
 
   render() {
     return (
-      <div>
+      <div ref="NewsfeedRef">
         {this.state.articles.length ? (
           <div style={{ overflow: "scroll", height: 400 }}>
             {this.state.articles.map((article, index) => (

--- a/client/src/pages/Login/Login.js
+++ b/client/src/pages/Login/Login.js
@@ -26,6 +26,12 @@ class Login extends Component {
     this.setState({ successMessage });
   }
 
+  componentWillUnmount() {
+    this.setState({
+      errors: {}
+    });
+  }
+
   handleFormSubmit = event => {
     event.preventDefault();
 
@@ -41,10 +47,6 @@ class Login extends Component {
 
       this.props.history.push(
         userObj.role === "athlete" ? "/athlete" : "/coach");
-
-      this.setState({
-        errors: {}
-      });
     }).catch( ({ response }) => {
       const errors = response.data.errors ? response.data.errors : {};
       errors.summary = response.data.message;

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,21 +1,21 @@
 const validator = require("validator");
 const passport = require("passport");
 
-const validateSignupForm = form => {
+const validateSignupForm = payload => {
   const errors = {};
   let isFormValid = true;
   let message = "";
 
-  if (!form 
-      || typeof form.email !== "string" 
-      || !validator.isEmail(form.email)) {
+  if (!payload 
+      || typeof payload.email !== "string" 
+      || !validator.isEmail(payload.email)) {
     isFormValid = false;
     errors.email = "Please provide a correct email address.";
   }
 
-  if (!form 
-      || typeof form.password !== "string" 
-      || !(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})/.test(form.password.trim()))) {
+  if (!payload 
+      || typeof payload.password !== "string" 
+      || !(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})/.test(payload.password.trim()))) {
     isFormValid = false;
       // Password criteria :
   // ^	          The password string will start this way
@@ -38,21 +38,21 @@ const validateSignupForm = form => {
   };
 }
 
-const validateLoginForm = form => {
+const validateLoginForm = payload => {
   const errors = {};
   let isFormValid = true;
   let message = "";
 
-  if (!form 
-      || typeof form.email !== "string" 
-      || form.email.trim().length === 0) {
+  if (!payload 
+      || typeof payload.email !== "string" 
+      || payload.email.trim().length === 0) {
     isFormValid = false;
     errors.email = "Please provide your email address.";
   }
 
-  if (!form 
-      || typeof form.password !== "string" 
-      || form.password.trim().length === 0) {
+  if (!payload 
+      || typeof payload.password !== "string" 
+      || payload.password.trim().length === 0) {
     isFormValid = false;
     errors.password = "Please provide your password.";
   }
@@ -81,7 +81,7 @@ module.exports = {
       });
     }
 
-    return passport.authenticate("local-signup", err => {
+    return passport.authenticate("local-signup", (err, token, userData) => {
       if (err) {
         if (err.name === "MongoError" && err.code === 11000) {
           // the 11000 Mongo code is for a duplication email error
@@ -103,7 +103,9 @@ module.exports = {
 
       return res.status(200).json({
         success: true,
-        message: "You have successfully signed up! Now you should be able to log in."
+        message: "You have successfully signed up! Now logging you in!",
+        token,
+        user: userData
       });
     })(req, res, next);
   },
@@ -134,7 +136,7 @@ module.exports = {
         });
       }
 
-      return res.json({
+      return res.status(200).json({
         success: true,
         message: "You have successfully logged in!",
         token,

--- a/middleware/auth-check.js
+++ b/middleware/auth-check.js
@@ -12,10 +12,9 @@ module.exports = (req, res, next) => {
 
   // decode the token using a secret key-phrase
   return jwt.verify(token, config.jwtSecret, (err, decoded) => {
+
     // the 401 code is for unauthorized status
-    if (err) { 
-      console.log(err);
-      return res.status(401).end(); }
+    if (err) { return res.status(401).end(); }
 
     const userId = decoded.sub;
 

--- a/passport/local-signup.js
+++ b/passport/local-signup.js
@@ -1,5 +1,7 @@
-const db = require("../models");
-const PassportLocalStrategy = require('passport-local').Strategy;
+const jwt = require("jsonwebtoken");
+const db  = require("../models");
+const PassportLocalStrategy = require("passport-local").Strategy;
+const config = require("../config");
 
 /**
  * Return the Passport Local Strategy object.
@@ -19,6 +21,16 @@ module.exports = new PassportLocalStrategy({
   db.Users.create(userData, (err, user) => {
     if (err) { return done(err); }
 
-    return done(null);
+    const payload = {
+      sub: user._id
+    };
+
+    // create a token string
+    const token = jwt.sign(payload, config.jwtSecret);
+    const data = {
+      name: user.name
+    };
+
+    return done(null, token, data);
   });
 });


### PR DESCRIPTION
Sign-up strategy was set up to just sign up and then require the user to log in. This does not fit our scenario. Changed sign-up strategy to automatically log in after registration. Now server passes token to client for use when authenticating for apis.

This branch also includes the fixes for the setState console.log warnings.